### PR TITLE
FIX: LFG cannot send messages to users

### DIFF
--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -415,7 +415,7 @@ namespace PolonyBot.Modules.LFG
                 }
                 else
                 {
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using PolonyBot.Modules.LFG.DAL;
 using PolonyBot.Modules.LFG.Utils;
+using Discord.Net;
 
 [assembly:InternalsVisibleTo("PolonyBot.UnitTests")]
 namespace PolonyBot.Modules.LFG
@@ -393,9 +394,23 @@ namespace PolonyBot.Modules.LFG
             return response;
         }
 
-        private Task<IUserMessage> CustomSendMessageAsync(string message)
+        private async Task CustomSendMessageAsync(string message)
         {
-            return CommandContext.User.SendMessageAsync(message.AsDiscordResponse());
+            try
+            {
+                await CommandContext.User.SendMessageAsync(message.AsDiscordResponse());
+            }
+            catch (HttpException e)
+            {
+                if (e.DiscordCode == 50007)
+                {
+                    await CommandContext.Channel.SendMessageAsync(message.AsDiscordResponse());
+                }
+                else
+                {
+                    throw e;
+                }
+            }
         }
 
         private Task<IUserMessage> CustomReplyAsync(string message)

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -410,7 +410,7 @@ namespace PolonyBot.Modules.LFG
                     }
                     else
                     {
-                        await CommandContext.Channel.SendMessageAsync("Unable to respond to your command via DM. Please check your privacy settings to receive the message.");
+                        await CommandContext.Channel.SendMessageAsync("Unable to respond to your command via DM. Please check your privacy settings.");
                     }
                 }
                 else

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -406,11 +406,11 @@ namespace PolonyBot.Modules.LFG
                 {
                     if (fallbackToChannelOnFail)
                     {
-                        await CommandContext.Channel.SendMessageAsync(message.AsDiscordResponse());
+                        await CustomReplyAsync(message.AsDiscordResponse());
                     }
                     else
                     {
-                        await CommandContext.Channel.SendMessageAsync("Unable to respond to your command via DM. Please check your privacy settings.");
+                        await CustomReplyAsync("Unable to respond to your command via DM. Please check your privacy settings.");
                     }
                 }
                 else

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -404,14 +404,9 @@ namespace PolonyBot.Modules.LFG
             {
                 if (e.DiscordCode == 50007)
                 {
-                    if (fallbackToChannelOnFail)
-                    {
-                        await CustomReplyAsync(message.AsDiscordResponse());
-                    }
-                    else
-                    {
-                        await CustomReplyAsync("Unable to respond to your command via DM. Please check your privacy settings.");
-                    }
+                    string response = fallbackToChannelOnFail ? message.AsDiscordResponse() : "Unable to respond to your command via DM. Please check your privacy settings.";
+
+                    await CustomReplyAsync(response);
                 }
                 else
                 {

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -408,6 +408,10 @@ namespace PolonyBot.Modules.LFG
                     {
                         await CommandContext.Channel.SendMessageAsync(message.AsDiscordResponse());
                     }
+                    else
+                    {
+                        await CommandContext.Channel.SendMessageAsync("Unable to respond to your command via DM. Please check your privacy settings to receive the message.");
+                    }
                 }
                 else
                 {

--- a/PolonyBot.Modules.LFG/LfgModule.cs
+++ b/PolonyBot.Modules.LFG/LfgModule.cs
@@ -107,17 +107,17 @@ namespace PolonyBot.Modules.LFG
                 case "?":
                     response = ListSupportedGames();
                     await Dao.InsertCommand(CommandContext.User.Id, CommandContext.User.Username, "LIST-SUPPORTED-GAMES", "").ConfigureAwait(false);
-                    await CustomSendMessageAsync($"```{response}```").ConfigureAwait(false);
+                    await CustomSendMessageAsync($"```{response}```", fallbackToChannelOnFail: true).ConfigureAwait(false);
                     break;
                 case "help":
                     response = GetHelpMessage();
                     await Dao.InsertCommand(CommandContext.User.Id, CommandContext.User.Username, "HELP", "").ConfigureAwait(false);
-                    await CustomSendMessageAsync(response).ConfigureAwait(false);
+                    await CustomSendMessageAsync(response, fallbackToChannelOnFail: true).ConfigureAwait(false);
                     break;
                 case "-":
                     LfgList.RemoveAll(x => x.User.Id == CommandContext.User.Id);
                     await Dao.InsertCommand(CommandContext.User.Id, CommandContext.User.Username, "REMOVE", "").ConfigureAwait(false);
-                    await CustomSendMessageAsync($"You have been removed from all LFG queues").ConfigureAwait(false);
+                    await CustomSendMessageAsync($"You have been removed from all LFG queues", fallbackToChannelOnFail: true).ConfigureAwait(false);
                     break;
                 default:
                     if (!_games.TryGetValue(game, out GameLabel description))
@@ -394,7 +394,7 @@ namespace PolonyBot.Modules.LFG
             return response;
         }
 
-        private async Task CustomSendMessageAsync(string message)
+        private async Task CustomSendMessageAsync(string message, bool fallbackToChannelOnFail = false)
         {
             try
             {
@@ -404,7 +404,10 @@ namespace PolonyBot.Modules.LFG
             {
                 if (e.DiscordCode == 50007)
                 {
-                    await CommandContext.Channel.SendMessageAsync(message.AsDiscordResponse());
+                    if (fallbackToChannelOnFail)
+                    {
+                        await CommandContext.Channel.SendMessageAsync(message.AsDiscordResponse());
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Added a fallback to send message to channel if the user has denied DM permission.
Only use fallback on certain commands.
Set a user friendly message on error.

https://app.clubhouse.io/safgc/story/56/polonybot-lfg-cannot-send-messages-to-users-who-have-disabled-direct-messages-from-non-friend-users